### PR TITLE
chore: streamline CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,165 +8,100 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Linux build and test
-  linux-build:
-    name: Linux Build and Test
-    runs-on: ubuntu-latest
+  build-test:
+    name: ${{ matrix.display_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            display_name: Linux Build & Test
+            shell: bash
+            cache_path: |
+              ~/.cache/CPM
+            cpm_cache_dir: ~/.cache/CPM
+            configure: |
+              cmake -S . -B build/linux-x64 \
+                    -DCMAKE_BUILD_TYPE=Release \
+                    -DBUILD_TESTS=ON \
+                    -DBUILD_DIAGNOSTIC=ON \
+                    -DBUILD_SHARED_LIBS=OFF \
+                    -G Ninja
+            build: cmake --build build/linux-x64 --parallel
+            test: |
+              cd build/linux-x64
+              ctest --output-on-failure
+            install: |
+              sudo apt-get update
+              sudo apt-get install -y \
+                build-essential \
+                clang \
+                lld \
+                pkg-config \
+                cmake \
+                ninja-build
+          - os: windows-latest
+            display_name: Windows Build & Test
+            shell: pwsh
+            cache_path: |
+              ~/.cache/CPM
+              ~/AppData/Local/Temp/CPM
+            cpm_cache_dir: ~/AppData/Local/Temp/CPM
+            configure: |
+              cmake -S . -B build/windows-x64 `
+                    -DCMAKE_BUILD_TYPE=Release `
+                    -DBUILD_TESTS=ON `
+                    -DBUILD_DIAGNOSTIC=ON `
+                    -DBUILD_SHARED_LIBS=OFF `
+                    -A x64
+            build: cmake --build build/windows-x64 --config Release --parallel
+            test: |
+              cd build/windows-x64
+              ctest --output-on-failure -C Release
+            install: ""
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup CPM dependencies cache
+      - name: Cache CPM dependencies
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/CPM
-            ~/AppData/Local/Temp/CPM
-          key: cpm-${{ runner.os }}-linux-${{ hashFiles('**/CMakeLists.txt') }}
+          path: ${{ matrix.cache_path }}
+          key: cpm-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            cpm-${{ runner.os }}-linux-
+            cpm-${{ runner.os }}-
 
-      - name: Setup build cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/**/CMakeCache.txt
-            build/**/CMakeFiles/**
-            build/**/cmake_install.cmake
-          key: build-${{ runner.os }}-linux-${{ hashFiles('**/CMakeLists.txt', '**/src/**', '**/include/**', '**/cli/**') }}
-          restore-keys: |
-            build-${{ runner.os }}-linux-
-
-      - name: Install dependencies
+      - name: Configure CPM cache directory
+        if: runner.os == 'Linux'
+        shell: bash
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            build-essential \
-            clang \
-            lld \
-            pkg-config \
-            cmake \
-            ninja-build
+          mkdir -p "${{ matrix.cpm_cache_dir }}"
+          echo "CPM_SOURCE_CACHE=${{ matrix.cpm_cache_dir }}" >> $GITHUB_ENV
+
+      - name: Configure CPM cache directory (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Path "${{ matrix.cpm_cache_dir }}" -Force | Out-Null
+          "CPM_SOURCE_CACHE=${{ matrix.cpm_cache_dir }}" | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: Install build dependencies
+        if: matrix.install != ''
+        shell: ${{ matrix.shell }}
+        run: ${{ matrix.install }}
 
       - name: Configure CMake
-        run: |
-          cmake -B build/linux-x64 \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DBUILD_TESTS=ON \
-                -DBUILD_DIAGNOSTIC=ON \
-                -DBUILD_SHARED_LIBS=OFF \
-                -G Ninja
+        shell: ${{ matrix.shell }}
+        run: ${{ matrix.configure }}
 
-      - name: Build Linux binaries
-        run: |
-          cmake --build build/linux-x64 --parallel $(nproc)
+      - name: Build
+        shell: ${{ matrix.shell }}
+        run: ${{ matrix.build }}
 
       - name: Run tests
-        run: |
-          cd build/linux-x64 && ctest --output-on-failure
-
-  # Windows native build and test
-  windows-build:
-    name: Windows Build and Test
-    runs-on: windows-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup CPM dependencies cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/CPM
-            ~/AppData/Local/Temp/CPM
-          key: cpm-${{ runner.os }}-windows-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: |
-            cpm-${{ runner.os }}-windows-
-
-      - name: Setup build cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/**/CMakeCache.txt
-            build/**/CMakeFiles/**
-            build/**/cmake_install.cmake
-          key: build-${{ runner.os }}-windows-${{ hashFiles('**/CMakeLists.txt', '**/src/**', '**/include/**', '**/cli/**') }}
-          restore-keys: |
-            build-${{ runner.os }}-windows-
-
-      - name: Configure CMake for Windows
-        shell: pwsh
-        run: |
-          cmake -B build/windows-x64 `
-                -DCMAKE_BUILD_TYPE=Release `
-                -DBUILD_TESTS=ON `
-                -DBUILD_DIAGNOSTIC=ON `
-                -DBUILD_SHARED_LIBS=OFF `
-                -A x64
-
-      - name: Build Windows binaries
-        shell: pwsh
-        run: |
-          cmake --build build/windows-x64 --config Release --parallel
-
-      - name: Run tests
-        shell: pwsh
-        run: |
-          cd build/windows-x64
-          ctest --output-on-failure -C Release
-
-  # macOS build and test
-  macos-build:
-    name: macOS Build and Test
-    runs-on: macos-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup CPM dependencies cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/CPM
-            ~/AppData/Local/Temp/CPM
-          key: cpm-${{ runner.os }}-macos-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: |
-            cpm-${{ runner.os }}-macos-
-
-      - name: Setup build cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/**/CMakeCache.txt
-            build/**/CMakeFiles/**
-            build/**/cmake_install.cmake
-          key: build-${{ runner.os }}-macos-${{ hashFiles('**/CMakeLists.txt', '**/src/**', '**/include/**', '**/cli/**') }}
-          restore-keys: |
-            build-${{ runner.os }}-macos-
-
-      - name: Install dependencies
-        run: |
-          brew install cmake ninja
-
-      - name: Configure CMake
-        run: |
-          cmake -B build/macos-x64 \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DBUILD_TESTS=ON \
-                -DBUILD_DIAGNOSTIC=ON \
-                -DBUILD_SHARED_LIBS=OFF \
-                -G Ninja
-
-      - name: Build macOS binaries
-        run: |
-          cmake --build build/macos-x64 --parallel $(sysctl -n hw.ncpu)
-
-      - name: Run tests
-        run: |
-          cd build/macos-x64 && ctest --output-on-failure
+        shell: ${{ matrix.shell }}
+        run: ${{ matrix.test }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,38 +12,50 @@ permissions:
   contents: write
 
 jobs:
-  # Linux build and release
-  linux-build:
-    name: Build for Linux
+  prepare:
+    name: Prepare metadata
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup CPM dependencies cache
+      - name: Extract version
+        id: version
+        run: |
+          VERSION=$(cmake -P cmake/print_version.cmake)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Build version: $VERSION"
+
+  package-linux:
+    name: Package Linux build
+    runs-on: ubuntu-latest
+    needs: prepare
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Cache CPM dependencies
         uses: actions/cache@v4
         with:
-          path: |
-            ~/.cache/CPM
-            ~/AppData/Local/Temp/CPM
-          key: cpm-${{ runner.os }}-linux-${{ hashFiles('**/CMakeLists.txt') }}
+          path: ~/.cache/CPM
+          key: cpm-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            cpm-${{ runner.os }}-linux-
+            cpm-${{ runner.os }}-
 
-      - name: Setup build cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/**/CMakeCache.txt
-            build/**/CMakeFiles/**
-            build/**/cmake_install.cmake
-          key: build-${{ runner.os }}-linux-${{ hashFiles('**/CMakeLists.txt', '**/src/**', '**/include/**', '**/cli/**') }}
-          restore-keys: |
-            build-${{ runner.os }}-linux-
+      - name: Configure CPM cache directory
+        run: |
+          mkdir -p "$HOME/.cache/CPM"
+          echo "CPM_SOURCE_CACHE=$HOME/.cache/CPM" >> $GITHUB_ENV
 
-      - name: Install dependencies
+      - name: Install build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -52,18 +64,11 @@ jobs:
             lld \
             pkg-config \
             cmake \
-            ninja-build \
-            zip
-
-      - name: Extract version
-        run: |
-          VERSION=$(cmake -P cmake/print_version.cmake)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          echo "Build version: $VERSION"
+            ninja-build
 
       - name: Configure CMake
         run: |
-          cmake -B build/linux-x64 \
+          cmake -S . -B build/linux-x64 \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DBUILD_TESTS=OFF \
                 -DBUILD_DIAGNOSTIC=ON \
@@ -72,7 +77,7 @@ jobs:
 
       - name: Build Linux binaries
         run: |
-          cmake --build build/linux-x64 --parallel $(nproc)
+          cmake --build build/linux-x64 --parallel
 
       - name: Verify binaries
         run: |
@@ -83,17 +88,13 @@ jobs:
         run: |
           mkdir -p release/linux-x86_64
 
-          # Copy binaries
           cp build/linux-x64/bin/art2img release/linux-x86_64/art2img
           cp build/linux-x64/bin/art2img_diagnostic release/linux-x86_64/art2img_diagnostic
-
-          # Copy documentation
           cp README.md release/linux-x86_64/
           cp LICENSE release/linux-x86_64/ 2>/dev/null || echo "No LICENSE file found"
 
-          # Create platform-specific README
-          cat > release/linux-x86_64/README.txt << EOF
-          art2img ${{ env.VERSION }} - linux-x86_64
+          cat > release/linux-x86_64/README.txt <<EOF
+          art2img ${VERSION} - linux-x86_64
 
           Multi-threaded ART to image converter for Duke Nukem 3D assets.
 
@@ -107,61 +108,49 @@ jobs:
           See README.md for full documentation.
           EOF
 
-          # Create archive
-          tar -czf art2img-linux-x86_64-${{ env.VERSION }}.tar.gz -C release/linux-x86_64 .
+          tar -czf art2img-linux-x86_64-${VERSION}.tar.gz -C release/linux-x86_64 .
 
-          echo "Package created: art2img-linux-x86_64-${{ env.VERSION }}.tar.gz"
+          echo "Package created: art2img-linux-x86_64-${VERSION}.tar.gz"
 
-      - name: Upload artifacts
+      - name: Upload Linux artifact
         uses: actions/upload-artifact@v4
         with:
           name: art2img-linux-x86_64
-          path: |
-            art2img-linux-x86_64-*.tar.gz
+          path: art2img-linux-x86_64-${VERSION}.tar.gz
           retention-days: 30
 
-  # Windows build and release
-  windows-build:
-    name: Build for Windows
+  package-windows:
+    name: Package Windows build
     runs-on: windows-latest
+    needs: prepare
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Setup CPM dependencies cache
+      - name: Cache CPM dependencies
         uses: actions/cache@v4
         with:
           path: |
             ~/.cache/CPM
             ~/AppData/Local/Temp/CPM
-          key: cpm-${{ runner.os }}-windows-${{ hashFiles('**/CMakeLists.txt') }}
+          key: cpm-${{ runner.os }}-${{ hashFiles('**/CMakeLists.txt') }}
           restore-keys: |
-            cpm-${{ runner.os }}-windows-
+            cpm-${{ runner.os }}-
 
-      - name: Setup build cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/**/CMakeCache.txt
-            build/**/CMakeFiles/**
-            build/**/cmake_install.cmake
-          key: build-${{ runner.os }}-windows-${{ hashFiles('**/CMakeLists.txt', '**/src/**', '**/include/**', '**/cli/**') }}
-          restore-keys: |
-            build-${{ runner.os }}-windows-
-
-      - name: Extract version
+      - name: Configure CPM cache directory
         shell: pwsh
         run: |
-          $VERSION = $(cmake -P cmake/print_version.cmake)
-          echo "VERSION=$VERSION" >> $env:GITHUB_ENV
-          echo "Build version: $VERSION"
+          New-Item -ItemType Directory -Path "$HOME\AppData\Local\Temp\CPM" -Force | Out-Null
+          "CPM_SOURCE_CACHE=$HOME\AppData\Local\Temp\CPM" | Out-File -FilePath $env:GITHUB_ENV -Append
 
-      - name: Configure CMake for Windows
+      - name: Configure CMake
         shell: pwsh
         run: |
-          cmake -B build/windows-x64 `
+          cmake -S . -B build/windows-x64 `
                 -DCMAKE_BUILD_TYPE=Release `
                 -DBUILD_TESTS=OFF `
                 -DBUILD_DIAGNOSTIC=ON `
@@ -210,19 +199,15 @@ jobs:
       - name: Create package
         shell: pwsh
         run: |
-          New-Item -ItemType Directory -Path "release\windows-x64" -Force
+          New-Item -ItemType Directory -Path "release\windows-x64" -Force | Out-Null
 
-          # Copy binaries
           Copy-Item "$env:CLI_BINARY" -Destination "release\windows-x64\"
           Copy-Item "$env:DIAGNOSTIC_BINARY" -Destination "release\windows-x64\"
-
-          # Copy documentation
           Copy-Item "README.md" -Destination "release\windows-x64\"
           Copy-Item "LICENSE" -Destination "release\windows-x64\" -ErrorAction SilentlyContinue
 
-          # Create platform-specific README
           $content = @"
-          art2img ${{ env.VERSION }} - windows-x64
+          art2img ${env:VERSION} - windows-x64
 
           Multi-threaded ART to image converter for Duke Nukem 3D assets.
 
@@ -237,189 +222,81 @@ jobs:
           "@
           $content | Out-File -FilePath "release\windows-x64\README.txt" -Encoding UTF8
 
-          # Create ZIP archive (PowerShell 5.1+)
-          Compress-Archive -Path "release\windows-x64\*" -DestinationPath "art2img-windows-x64-${{ env.VERSION }}.zip"
+          Compress-Archive -Path "release\windows-x64\*" -DestinationPath "art2img-windows-x64-${env:VERSION}.zip"
 
-          Write-Host "Package created: art2img-windows-x64-${{ env.VERSION }}.zip"
+          Write-Host "Package created: art2img-windows-x64-${env:VERSION}.zip"
 
-      - name: Upload artifacts
+      - name: Upload Windows artifact
         uses: actions/upload-artifact@v4
         with:
           name: art2img-windows-x64
-          path: |
-            art2img-windows-x64-*.zip
+          path: art2img-windows-x64-${{ env.VERSION }}.zip
           retention-days: 30
 
-  # macOS build and release
-  macos-build:
-    name: Build for macOS
-    runs-on: macos-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Setup CPM dependencies cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cache/CPM
-            ~/AppData/Local/Temp/CPM
-          key: cpm-${{ runner.os }}-macos-${{ hashFiles('**/CMakeLists.txt') }}
-          restore-keys: |
-            cpm-${{ runner.os }}-macos-
-
-      - name: Setup build cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            build/**/CMakeCache.txt
-            build/**/CMakeFiles/**
-            build/**/cmake_install.cmake
-          key: build-${{ runner.os }}-macos-${{ hashFiles('**/CMakeLists.txt', '**/src/**', '**/include/**', '**/cli/**') }}
-          restore-keys: |
-            build-${{ runner.os }}-macos-
-
-      - name: Install dependencies
-        run: |
-          brew install cmake ninja
-
-      - name: Configure CMake
-        run: |
-          cmake -B build/macos-x64 \
-                -DCMAKE_BUILD_TYPE=Release \
-                -DBUILD_TESTS=OFF \
-                -DBUILD_DIAGNOSTIC=ON \
-                -DBUILD_SHARED_LIBS=OFF \
-                -G Ninja
-
-      - name: Build macOS binaries
-        run: |
-          cmake --build build/macos-x64 --parallel $(sysctl -n hw.ncpu)
-
-      - name: Verify binaries
-        run: |
-          file build/macos-x64/bin/art2img | grep -q "Mach-O" && echo "macOS binary verified"
-          file build/macos-x64/bin/art2img_diagnostic | grep -q "Mach-O" && echo "macOS diagnostic verified"
-
-      - name: Create macOS package
-        run: |
-          VERSION=$(cmake -P cmake/print_version.cmake)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-          mkdir -p release/macos-x86_64
-
-          # Copy binaries
-          cp build/macos-x64/bin/art2img release/macos-x86_64/art2img
-          cp build/macos-x64/bin/art2img_diagnostic release/macos-x86_64/art2img_diagnostic
-
-          # Copy documentation
-          cp README.md release/macos-x86_64/
-          cp LICENSE release/macos-x86_64/ 2>/dev/null || echo "No LICENSE file found"
-
-          # Create platform-specific README
-          cat > release/macos-x86_64/README.txt << EOF
-          art2img $VERSION - macos-x86_64
-
-          Multi-threaded ART to image converter for Duke Nukem 3D assets.
-
-          Binaries:
-          - art2img - Main converter
-          - art2img_diagnostic - Diagnostic tool
-
-          Quick Start:
-          ./art2img -f png -p PALETTE.DAT TILES000.ART
-
-          See README.md for full documentation.
-          EOF
-
-          # Create ZIP archive
-          cd release/macos-x86_64
-          zip -r ../art2img-macos-x86_64-$VERSION.zip .
-          cd ../..
-
-          echo "Package created: art2img-macos-x86_64-$VERSION.zip"
-
-      - name: Upload macOS artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: art2img-macos-x86_64
-          path: |
-            art2img-macos-x86_64-*.zip
-          retention-days: 30
-
-  # Release job - run on release
-  release:
-    name: Create GitHub Release
+  publish:
+    name: Publish GitHub release
     runs-on: ubuntu-latest
-    needs: [linux-build, windows-build, macos-build]
+    needs:
+      - prepare
+      - package-linux
+      - package-windows
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download all build artifacts
+      - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
           path: artifacts/
 
-      - name: Determine version
+      - name: Determine tag name
         run: |
-          VERSION=$(cmake -P cmake/print_version.cmake)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
           TAG_SOURCE="${GITHUB_REF_NAME:-${{ github.event.release.tag_name || '' }}}"
           if [ -z "$TAG_SOURCE" ]; then
-            TAG_SOURCE="$VERSION"
+            TAG_SOURCE="${VERSION}"
           fi
           echo "TAG_NAME=$TAG_SOURCE" >> $GITHUB_ENV
 
       - name: Generate release notes
         run: |
-          cat > release-notes.md << EOF
-          # art2img ${{ env.TAG_NAME }}
+          cat > release-notes.md <<EOF
+          # art2img ${TAG_NAME}
 
-          Multi-threaded ART to image converter for Duke Nukem 3D assets with support for multiple platforms and architectures.
+          Multi-threaded ART to image converter for Duke Nukem 3D assets with prebuilt packages for Linux and Windows.
 
           ## Downloads
 
           ### Linux
-          - **x86_64**: \`art2img-linux-x86_64-*.tar.gz\`
+          - **x86_64**: \`art2img-linux-x86_64-${VERSION}.tar.gz\`
 
           ### Windows
-          - **x86_64**: \`art2img-windows-x64-*.zip\`
-
-          ### macOS
-          - **x86_64**: \`art2img-macos-x86_64-*.zip\`
+          - **x86_64**: \`art2img-windows-x64-${VERSION}.zip\`
 
           ## Installation
 
           ### Linux
           \`\`\`bash
-          tar -xzf art2img-linux-x86_64-*.tar.gz
+          tar -xzf art2img-linux-x86_64-${VERSION}.tar.gz
           ./art2img --help
           \`\`\`
 
           ### Windows
           \`\`\`powershell
-          Expand-Archive art2img-windows-x64-*.zip
+          Expand-Archive art2img-windows-x64-${VERSION}.zip
           .\art2img.exe --help
-          \`\`\`
-
-          ### macOS
-          \`\`\`bash
-          unzip art2img-macos-x86_64-*.zip
-          ./art2img --help
           \`\`\`
 
           ## Features
           - Multi-threaded extraction
           - PNG and TGA output with alpha channel support
           - Animation data extraction
-          - Cross-platform compatibility
+          - Cross-platform compatibility (Linux & Windows)
           - Static binaries (no dependencies required)
 
           ## Verification
-          All binaries are statically linked and digitally verified. No additional dependencies required.
+          All binaries are statically built and verified during CI. No additional dependencies required.
 
           ---
           [Full Documentation](https://github.com/raulcorreia7/art2img)

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ JOBS ?= $(shell nproc)
 VERSION ?= $(shell cmake -P cmake/print_version.cmake)
 
 # Run integration tests for different platforms
+.PHONY: test-intg test-intg-windows test-intg-windows-x86 test-intg-release
 test-intg: build
 	@BUILD_TYPE=linux ./scripts/run_bats_tests.sh
 
@@ -21,9 +22,9 @@ test-intg-release: linux-x64-release
 	@BUILD_TYPE=linux-x64-release ./scripts/run_bats_tests.sh
 
 # Main targets
-.PHONY: all build test clean install format fmt fmt-check lint help
-.PHONY: mingw-windows mingw-windows-x86 test-windows doctor test-bats
-.PHONY: linux-x64-release windows-x64-release windows-x86-release
+.PHONY: all build test clean install format fmt fmt-check lint help doctor
+.PHONY: mingw-windows mingw-windows-x86 mingw-windows-x64-release mingw-windows-x86-release
+.PHONY: linux-x64-release release test-windows test-windows-x86
 
 # Default target - build for Linux
 all: build
@@ -50,6 +51,10 @@ mingw-windows-x64-release:
 
 mingw-windows-x86-release:
 	@./scripts/build/cross/mingw-windows32.sh --build-dir $(BUILD_DIR)/mingw-windows-x86-release --build-type Release -j $(JOBS)
+
+.PHONY: release
+release: linux-x64-release mingw-windows-x64-release
+
 
 # Run tests on Linux
 test: build
@@ -98,6 +103,7 @@ help:
 	@echo "  make linux-x64-release       - Build + test release configuration for Linux x64"
 	@echo "  make mingw-windows-x64-release     - Build release configuration for Windows x64 using MinGW"
 	@echo "  make mingw-windows-x86-release - Build release configuration for Windows x86 using MinGW"
+	@echo "  make release      - Build all supported release artifacts (Linux + Windows x64)"
 	@echo "  make test         - Run tests on Linux"
 	@echo "  make test-intg         - Run integration tests for Linux"
 	@echo "  make test-intg-windows - Run integration tests for Windows (cross-compiled)"

--- a/REVIEW_NOTES.md
+++ b/REVIEW_NOTES.md
@@ -1,12 +1,14 @@
 # Review Notes
 
 ## Repository Survey
-- **Languages:** C++20 for core and CLI, CMake for build scripts, doctest for C++ tests.
-- **Toolchain:** Build via `make all`, tests with `make test`; CMake integrates CLI11, doctest, fmt, stb.
-- **CI Signals:** GitHub Actions workflows cover build/test and release; recent upstream adds lint targets.
-- **Hotspots:** `cli/processor.cpp` handles most workflow complexity (parallel exports, progress, error reporting).
-- **Risks:** Parallel export uses a thread pool; ensure thread count flags stay consistent across CLI parsing and processing. Merge conflicts likely in CLI files when adding new options.
+- **Languages:** C++20 for core/CLI, CMake for build orchestration, Bash/PowerShell helper scripts, GitHub Actions YAML for CI/CD.
+- **Toolchains & Commands:** Primary workflow via `make` targets delegating to `scripts/build/...` wrappers; tests run with `ctest`. Version retrieved through `cmake -P cmake/print_version.cmake`.
+- **CI Workflows:** `ci.yml` runs Linux, Windows, macOS builds with duplicated cache/setup steps; `release.yml` mirrors packaging across platforms and generates release notes advertising macOS binaries.
+- **Dependencies:** Managed through CPM (cache stored under user temp dirs). Actions install toolchains each run; no compiler cache (`ccache`) or GitHub Actions matrix reuse.
+- **Quality Signals:** CI builds all platforms but lacks lint/format stages; release notes mention macOS although delivery is being dropped per request. Build scripts rely on Ninja.
+- **Hotspots/Risks:** Redundant workflow steps increase maintenance overhead; caches cover whole build trees risking stale artifacts; release job depends on macOS build; Makefile lacks phony declarations for test-intg variants.
 
-## Low-Risk Wins
-- Keep CLI option-to-processing translation centralized (`make_processing_options`).
-- Maintain deterministic directory traversal by sorting collected ART files.
+## Immediate Opportunities
+- Collapse repeated workflow logic via matrices/composite actions; tighten cache paths to avoid copying build trees.
+- Align release messaging with actual platform support (Linux & Windows) and ensure release job tolerates missing macOS artifacts.
+- Consider adding compiler caching or targeted dependency install scripts for faster runs.


### PR DESCRIPTION
## Summary
- collapse CI into a single matrix-driven job for Linux and Windows, caching CPM dependencies without persisting build artifacts
- restructure the release workflow to build Linux/Windows packages only, reuse a shared version job, and rewrite the notes without macOS messaging
- align the Makefile phony declarations and add a consolidated `release` target for supported platforms

## Testing
- make help

------
https://chatgpt.com/codex/tasks/task_e_68e578884b58832b967180fd15e3df72