### PR TITLE
fix(ci): prevent cache collisions between Windows x64 and Win32 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,9 @@ jobs:
       uses: actions/cache@v4
       with:
         path: .cache
-        key: ${{ runner.os }}-cpm-${{ hashFiles('cmake/CPM.cmake', '**/CMakeLists.txt') }}
+        key: ${{ runner.os }}-${{ matrix.arch || 'default' }}-cpm-${{ hashFiles('cmake/CPM.cmake', '**/CMakeLists.txt') }}
         restore-keys: |
-          ${{ runner.os }}-cpm-
+          ${{ runner.os }}-${{ matrix.arch || 'default' }}-cpm-
           
     - name: Configure CMake (Windows)
       if: runner.os == 'Windows'


### PR DESCRIPTION
Fixes cache collision issue in GitHub Actions workflow by adding architecture-specific cache keys to prevent conflicts between Windows x64 and Win32 builds.