### PR TITLE
Fix CI/CD pipelines to use single-threaded test execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,11 +84,11 @@ jobs:
       run: |
         cd build
         if [ "${{ runner.os }}" = "Windows" ]; then
-          ctest --output-on-failure --parallel 4 --timeout 300
+          ctest --output-on-failure --parallel 1 --timeout 300
         elif [ "${{ runner.os }}" = "macOS" ]; then
-          ctest --output-on-failure --parallel 4 --timeout 300
+          ctest --output-on-failure --parallel 1 --timeout 300
         else
-          ctest --output-on-failure --parallel 4 --timeout 300
+          ctest --output-on-failure --parallel 1 --timeout 300
         fi
         
     - name: Test Status Check

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,9 @@ if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type" FORCE)
 endif()
 
-# Enable parallel testing by default for CMake 3.29+
-if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.29")
-    set(CMAKE_CTEST_ARGUMENTS --parallel)
-endif()
+# Enable parallel testing by default for local development
+# CI/CD pipelines will override this with --parallel 1
+set(CMAKE_CTEST_ARGUMENTS --parallel)
 
 if(MSVC)
     add_compile_options(/W4)


### PR DESCRIPTION
## Summary
- Configure CI/CD pipelines to use single-threaded test execution (`--parallel 1`) for consistency and reliability
- Keep local development environment configured for parallel test execution using `$(JOBS)` variable
- Update CMake configuration to enable parallel testing by default for local development while allowing CI/CD to override with single-threaded execution

This change ensures that tests run consistently in CI/CD environments while maintaining optimal performance for local development.